### PR TITLE
Trigger on any characters

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import I18nHoverProvider from "./I18nHoverProvider";
 import I18nCodeActionProvider from "./I18nCodeActionProvider";
 
 const SELECTOR = ["ruby", "erb", "haml", "slim"];
+const TRIGGER_CHARS = `.abcdefghijklmnopqrstuvwxyz'"`.split("");
 
 export async function activate(context: vscode.ExtensionContext) {
   const globPettern = vscode.workspace.getConfiguration("railsI18n")
@@ -23,8 +24,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.languages.registerCompletionItemProvider(
       SELECTOR,
       new I18nTranslateCompletionProvider(i18n),
-      "'",
-      '"'
+      ...TRIGGER_CHARS
     )
   );
 
@@ -32,8 +32,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.languages.registerCompletionItemProvider(
       SELECTOR,
       new I18nTranslatePrefixCompletionProvider(i18n),
-      "'",
-      '"'
+      ...TRIGGER_CHARS
     )
   );
 


### PR DESCRIPTION
Hey, thanks for the extension. I think it would be great if the triggers can be expanded from `"` and `'` to any characters. For example, if you want to edit from `foo.bar` to `foo.baz`, you can triggers the suggestion from `foo.b`.