### PR TITLE
Goto definition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -110,6 +110,15 @@
 			"integrity": "sha512-SbHR3Q5g/C3N+Ila3KrRf1rSZiyHxWdOZ7X3yFHXzw6HrvRLuVZrxnwEX0lTBMRpH9LkwZdqRTgXW+D075jxkg==",
 			"dev": true
 		},
+		"@types/yaml": {
+			"version": "1.9.7",
+			"resolved": "https://registry.npmjs.org/@types/yaml/-/yaml-1.9.7.tgz",
+			"integrity": "sha512-8WMXRDD1D+wCohjfslHDgICd2JtMATZU8CkhH8LVJqcJs6dyYj5TGptzP8wApbmEullGBSsCEzzap73DQ1HJaA==",
+			"dev": true,
+			"requires": {
+				"yaml": "*"
+			}
+		},
 		"agent-base": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
@@ -1157,6 +1166,11 @@
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
 			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
 			"dev": true
+		},
+		"yaml": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+			"integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
 		},
 		"yargs": {
 			"version": "13.2.2",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@types/mocha": "^5.2.6",
     "@types/node": "^10.12.21",
     "@types/vscode": "^1.36.0",
+    "@types/yaml": "^1.9.7",
     "glob": "^7.1.4",
     "mocha": "^6.1.4",
     "tslint": "^5.12.1",
@@ -101,6 +102,7 @@
     "js-yaml": "^3.13.1",
     "lodash.frompairs": "^4.0.1",
     "lodash.merge": "^4.6.2",
-    "lodash.sortby": "^4.7.0"
+    "lodash.sortby": "^4.7.0",
+    "yaml": "^1.10.0"
   }
 }

--- a/src/I18nDefinitionProvider.ts
+++ b/src/I18nDefinitionProvider.ts
@@ -1,0 +1,61 @@
+import {
+  DefinitionProvider,
+  Range,
+  TextDocument,
+  Position,
+  Uri,
+  workspace,
+  Location
+} from "vscode";
+import I18n from './i18n';
+import KeyDetector from './KeyDetector';
+import YAML = require('yaml');
+import { Pair } from 'yaml/types';
+
+export default class I18nDefinitionProvider implements DefinitionProvider {
+  constructor(private i18n: I18n) { }
+
+  public async provideDefinition(document: TextDocument, position: Position) {
+    const keyAndRange = this.i18n.getKeyAndRange(document, position);
+    if (!keyAndRange) {
+      return;
+    }
+
+    const { key, range } = keyAndRange;
+    const normalizedKey = KeyDetector.asAbsoluteKey(key, document);
+    if (!normalizedKey) {
+      return;
+    }
+
+    const translation = this.i18n.get(normalizedKey);
+    if (!translation) {
+      return;
+    }
+
+    const absoluteKeys = KeyDetector.asAbsoluteKeys(translation.locale, normalizedKey, position, range);
+
+    return this.getDefinitionLocation(translation.path, absoluteKeys);
+  }
+
+  private async getDefinitionLocation(path: string, absoluteKeys: string[]) {
+    const targetUri = Uri.file(path);
+    const localeText = await workspace.openTextDocument(targetUri);
+
+    const contents = YAML.parseDocument(localeText.getText()).contents as any;
+    if (!contents) {
+      return;
+    }
+
+    const scalar = this.getScalar(contents, absoluteKeys);
+    const pos = localeText.positionAt(scalar.key.range[0]);
+
+    return new Location(targetUri, new Range(pos, pos));
+  }
+
+  private getScalar(contents: any, absoluteKeys: string[]) {
+    const lastKey = absoluteKeys.pop();
+    const rootScalar = contents.getIn(absoluteKeys)
+
+    return rootScalar.items.find((pair: Pair) => pair.key.value === lastKey);
+  }
+}

--- a/src/I18nHoverProvider.ts
+++ b/src/I18nHoverProvider.ts
@@ -17,11 +17,11 @@ export default class I18nHoverProvider implements HoverProvider {
       return;
     }
 
-    const value = this.i18n.get(normalizedKey);
-    if (!value) {
+    const translation = this.i18n.get(normalizedKey);
+    if (!translation) {
       return;
     }
 
-    return new Hover({ language: "text", value }, range);
+    return new Hover({ language: "text", value: translation.value }, range);
   }
 }

--- a/src/I18nLocalizeCompletionProvider.ts
+++ b/src/I18nLocalizeCompletionProvider.ts
@@ -69,7 +69,7 @@ export default class I18nLocalizeCompletionProvider
         const [type, , format] = key.split(".");
         const item = new CompletionItem(format, CompletionItemKind.Keyword);
         item.detail = type;
-        item.documentation = translation;
+        item.documentation = translation.value;
         return item;
       });
   }

--- a/src/I18nTranslateCompletionProvider.ts
+++ b/src/I18nTranslateCompletionProvider.ts
@@ -40,7 +40,7 @@ export default class I18nTranslateCompletionProvider
   private buildCompletinItems(range: Range) {
     return Array.from(this.i18n.entries()).map(([key, translation]) => {
       const item = new CompletionItem(key, CompletionItemKind.Keyword);
-      item.documentation = translation;
+      item.documentation = translation.value;
       item.range = range;
       return item;
     });

--- a/src/KeyDetector.ts
+++ b/src/KeyDetector.ts
@@ -1,4 +1,4 @@
-import { TextDocument, workspace } from "vscode";
+import { TextDocument, workspace, Position, Range } from "vscode";
 import * as path from "path";
 
 export default class KeyDetector {
@@ -21,5 +21,14 @@ export default class KeyDetector {
     const basename = path.basename(relativePath).split(".", 2)[0];
 
     return [...parts, basename].join(".") + key;
+  }
+
+  public static asAbsoluteKeys(locale: string, key: string, position: Position, range: Range) {
+    const relativeCursorPos = position.character - range.start.character;
+    const keySegmentLimit = key.slice(0, relativeCursorPos).split('.').length;
+
+    const fullKeys = key.split('.').slice(0, keySegmentLimit);
+
+    return [locale].concat(fullKeys);
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import I18nTranslatePrefixCompletionProvider from "./I18nTranslatePrefixCompleti
 import I18nLocalizeCompletionProvider from "./I18nLocalizeCompletionProvider";
 import I18nHoverProvider from "./I18nHoverProvider";
 import I18nCodeActionProvider from "./I18nCodeActionProvider";
+import I18nDefinitionProvider from './I18nDefinitionProvider';
 
 const SELECTOR = ["ruby", "erb", "haml", "slim"];
 
@@ -56,6 +57,13 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.languages.registerCodeActionsProvider(
       SELECTOR,
       new I18nCodeActionProvider(i18n)
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.languages.registerDefinitionProvider(
+      SELECTOR,
+      new I18nDefinitionProvider(i18n)
     )
   );
 }


### PR DESCRIPTION
Hey, thanks again for the extension. So in this PR, I'm implementing goto definition provider. I had to change couple of things.

1. Install `yaml` while keeping `js-yaml`, as `yaml` provides more information than just parser. But I'm also keeping the original implementation using `js-yaml` as I don't want to change too many things at once. Would be great if probably we can migrate to `yaml` eventually.

2. Had to introduce new `Translation` interface, as I have to pass `path` and `locale` info around.