### PR TITLE
Debounce load

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -9,6 +9,7 @@ import {
 } from "vscode";
 import sortBy from "lodash/sortBy";
 import arrayFlatten from "lodash/flatten";
+import debounce from "lodash/debounce";
 import escapeStringRegexp from "escape-string-regexp";
 import { priorityOfLocales } from "./utils";
 import { Parser, Translation } from './Parser';
@@ -90,6 +91,8 @@ export default class I18n {
     return !!document.getWordRangeAtPosition(position, this.i18nRegexp);
   }
 
+  private loadDebounced = debounce(this.load, 500);
+
   private createFileWatchers() {
     const workspaceFolders = vscode.workspace
       .workspaceFolders as WorkspaceFolder[];
@@ -101,7 +104,7 @@ export default class I18n {
     });
     fileWatchers.forEach(fileWatcher => {
       fileWatcher.onDidChange(() => {
-        this.load();
+        this.loadDebounced()
       });
     });
 


### PR DESCRIPTION
## What

Debounce `load` call when translation changed

## Why

The file watcher watches changes in all YAML files defined by the glob. In some cases, multiple YAML files can changed at the same time, for example, when switching between git branches.

If you have 100 YAML files, and all of them changed at the same time because you switch git branch, it will then call `load` 100 times unnecessarily. It makes VS code hang until everything finishes.

This PR will debounce the call to `load`, so in that case, the extension will only `load` once.