### PR TITLE
fix: detect nested locale files by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Configure the extension through VS Code settings:
 |---------|-------------|---------|
 | `railsI18n.translateMethods` | I18n translate methods | `["I18n.translate", "I18n.t", "t"]` |
 | `railsI18n.localizeMethods` | I18n localize methods | `["I18n.localize", "I18n.l", "l"]` |
-| `railsI18n.localeFilePattern` | Locale file glob pattern | `"config/locales/*.yml"` |
+| `railsI18n.localeFilePattern` | Locale file glob pattern | `"config/locales/**/*.yml"` |
 | `railsI18n.priorityOfLocales` | Priority order for languages | `["en"]` |
 | `railsI18n.languagesEnableHoverProvider` | Languages for hover support | `["ruby", "erb", "haml", "slim"]` |
 | `railsI18n.annotations` | Enable inline annotations | `true` |

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rails-i18n",
   "displayName": "Rails I18n",
   "description": "Completion, Hover and QuickFix provider for Rails I18n.",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "publisher": "aki77",
   "license": "MIT",
   "icon": "images/icon.png",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         },
         "railsI18n.localeFilePattern": {
           "type": "string",
-          "default": "config/locales/*.yml",
+          "default": "config/locales/**/*.yml",
           "description": "I18n locale file glob pattern"
         },
         "railsI18n.priorityOfLocales": {


### PR DESCRIPTION
## Overview

Fixes an issue where locale files nested in subdirectories (e.g. `config/locales/ja/hoge.yml`) were not detected with the default setting.

## Changes

- Change the default value of `railsI18n.localeFilePattern` from `config/locales/*.yml` to `config/locales/**/*.yml` (the glob `*` only matches a single path segment). This detects files both directly under `config/locales` and in nested subdirectories, while remaining backward compatible
- Update the default value shown in the settings table in the README